### PR TITLE
Return 404 when redirector page wants to link to missing page

### DIFF
--- a/src/Pages/RedirectionPage.php
+++ b/src/Pages/RedirectionPage.php
@@ -14,6 +14,7 @@ class RedirectionPage extends Page
     private static $table_name = 'RedirectionPage';
     private static $singular_name = 'Redirection Page';
     private static $plural_name = 'Redirection Pages';
+    private static $description = 'Redirect to a different target';
     private static $icon_class = 'font-icon-p-redirect';
 
     private static $show_stage_link = false;

--- a/src/Pages/RedirectionPageController.php
+++ b/src/Pages/RedirectionPageController.php
@@ -11,14 +11,20 @@ class RedirectionPageController extends PageController
 {
     private static $allowed_actions = ['index'];
 
+    private static $missing_redirect_is_404 = true;
+
     public function index(HTTPRequest $request): DBHTMLText|HTTPResponse
     {
         /** @var RedirectionPage $page */
         $page = $this->data();
         $isFinished = $this->getResponse()->isFinished();
-        if (!$isFinished && $page->hasValidTargetSuperLink()) {
-            $link = $page->getTargetSuperLink();
-            $this->redirect($link->getURL(), $link->getResponseCode());
+        if (!$isFinished) {
+            if ($page->hasValidTargetSuperLink()) {
+                $link = $page->getTargetSuperLink();
+                return $this->redirect($link->getURL(), $link->getResponseCode());
+            } elseif ($this->config()->missing_redirect_is_404) {
+                return $this->httpError(404);
+            }
         }
         return parent::handleAction($request, 'handleIndex');
     }


### PR DESCRIPTION
replicating the change to the SS RedirectorPage (https://github.com/silverstripe/silverstripe-cms/commit/a5d2b3bb32fc9709e81b2087d0e013e4bcdc4206). I think this makes more sense.