### PR TITLE
switch hide_ancestor to hide_pagetypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # silverstripe-superlinker-redirection
 
-Requires Silverstripe 5+.
+Requires Silverstripe 5.2+.
 
 Replace for OOTB Silverstripe Redirector Page, using a SuperLink target to select a much wider range of target types (than simple internal/external)
 

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -2,8 +2,11 @@
 Name: fromholdio-superlinker-redirection
 ---
 
+SilverStripe\CMS\Model\SiteTree:
+  hide_pagetypes:
+    - SilverStripe\CMS\Model\RedirectorPage
+
 SilverStripe\CMS\Model\RedirectorPage:
-  hide_ancestor: SilverStripe\CMS\Model\RedirectorPage
   extensions:
     fioHiddenPage: Fromholdio\HiddenPages\Extensions\HiddenPageExtension
 

--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
         "homepage": "https://fromhold.io"
     }],
     "require": {
-        "silverstripe/cms": "~5.0",
-        "fromholdio/silverstripe-superlinker": "^3.0.0",
-        "fromholdio/silverstripe-relativeurlfield": "^1.0.0",
-        "fromholdio/silverstripe-hidden-pages": "^1.1.0",
+        "silverstripe/cms": "^5.2",
+        "fromholdio/silverstripe-superlinker": "^3",
+        "fromholdio/silverstripe-relativeurlfield": "^1",
+        "fromholdio/silverstripe-hidden-pages": "^2",
         "stevie-mayhew/hasoneedit": "^2.2"
     },
     "autoload": {


### PR DESCRIPTION
depends on [pull to fromholdio/silverstripe-hidden-pages](https://github.com/fromholdio/silverstripe-hidden-pages/pull/1) being merged and tagged as 2.0.0.