### PR TITLE
Fix rewrite of origin URL, fixes #12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "silverstripe/cms": "^5.2",
         "fromholdio/silverstripe-superlinker": "^3",
-        "fromholdio/silverstripe-relativeurlfield": "^1",
+        "fromholdio/silverstripe-relativeurlfield": "^1.2",
         "fromholdio/silverstripe-hidden-pages": "^2",
         "stevie-mayhew/hasoneedit": "^2.2"
     },

--- a/src/Model/RedirectionSuperLink.php
+++ b/src/Model/RedirectionSuperLink.php
@@ -222,6 +222,8 @@ class RedirectionSuperLink extends SuperLink
         else {
             $fields = parent::getCMSLinkFields($fieldPrefix);
 
+            $fromURLField->setIsCleanValueEnabled(false);
+
             $codeField = OptionsetField::create(
                 $fieldPrefix . 'RedirectionResponseCode',
                 $this->fieldLabel('RedirectionResponseCode'),


### PR DESCRIPTION
Depends on https://github.com/fromholdio/silverstripe-relativeurlfield/pull/2 being tagged as 1.2.0!