### PR TITLE
Merge redirection origin URL index into 4.x

### DIFF
--- a/src/Model/RedirectionSuperLink.php
+++ b/src/Model/RedirectionSuperLink.php
@@ -84,6 +84,10 @@ class RedirectionSuperLink extends SuperLink
         'RedirectionResponseCode'
     ];
 
+    private static $indexes = [
+        'RedirectionFromRelativeURL' => true,
+    ];
+
     public function getFormattedOriginURL(): DBHTMLText
     {
         $url = $this->getOriginURL();


### PR DESCRIPTION
Ports the `RedirectionFromRelativeURL` database index from the 3.x line into the 4.x / Silverstripe 6 branch.

Original PR: #18

Validation:
- `php -l src/Model/RedirectionSuperLink.php`
- `git diff --check origin/master...HEAD`